### PR TITLE
Output Ordnerstruktur erstellt mit passenden Dateien (fixes #80)

### DIFF
--- a/Output/data/auslastung.txt
+++ b/Output/data/auslastung.txt
@@ -1,0 +1,1 @@
+Hier kommen die Auslastungsdaten jedes Schritts der Simulation rein.

--- a/Output/data/simulation_ende.txt
+++ b/Output/data/simulation_ende.txt
@@ -1,0 +1,1 @@
+Hier kommen die Enddaten der Simulation rein.

--- a/Output/gnuplot/plot_endergebnis.gp
+++ b/Output/gnuplot/plot_endergebnis.gp
@@ -1,0 +1,1 @@
+hier kommt der code zum Ploten des Endergebnis rein.


### PR DESCRIPTION
Ich habe einen neuen "Output" Ordner erstellt mit dem Unterordner "data" in welchem die Daten welche von den Simulationsausgabe Funktionen übergeben werden abgespeichert werden, und einem "gnuplot" Unterordner in welchem der Code für das ploten der finalen Ausgabe rein kommt.