### PR TITLE
end_simulationsdaten_ausgeben in C geschrieben & kleine Fixes

### DIFF
--- a/Code/src/Simulation.c
+++ b/Code/src/Simulation.c
@@ -292,6 +292,10 @@ void end_simulationsdaten_ausgeben(const Simulationdaten *p_daten)
 		printf("Simulationsergebnisse finden Sie in der externen Ergebnisdatei.\n");
 
 	}
+	else
+	{
+		printf("Fehler: Datei 'Output/data/simulation_ende.txt' konnte nicht geoeffnet werden.\n");
+	}
 
 	/*
 	Function end_simulationsdaten_ausgeben(const Simulationdaten *p_daten) //gibt am Ende der Simulation die Daten aus


### PR DESCRIPTION
Ich habe die Funktion in C geschrieben und den Pseudocode auskommentiert, außerdem habe ich mal alle anderen Pseudocode Funktionen auch auskommentiert, sodass mein beim Coden seine Fehler besser erkennt.